### PR TITLE
#5: Integrate Google Places API with App

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "fetch-places": "npx tsx scripts/fetchPlaces.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.4.1",

--- a/prisma/migrations/20250308235331_create_job_log_and_location_tables/migration.sql
+++ b/prisma/migrations/20250308235331_create_job_log_and_location_tables/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "JobLog" (
+    "id" SERIAL NOT NULL,
+    "jobName" TEXT NOT NULL,
+    "message" TEXT NOT NULL,
+    "runAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "JobLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Location" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "latitude" DOUBLE PRECISION NOT NULL,
+    "longitude" DOUBLE PRECISION NOT NULL,
+    "category" TEXT NOT NULL,
+    "address" TEXT NOT NULL,
+    "googlePlaceId" TEXT NOT NULL,
+    "profilePicture" TEXT,
+
+    CONSTRAINT "Location_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Location_googlePlaceId_key" ON "Location"("googlePlaceId");

--- a/prisma/migrations/20250309001040_add_rating_to_location/migration.sql
+++ b/prisma/migrations/20250309001040_add_rating_to_location/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Location" ADD COLUMN     "googleRatingsTotal" INTEGER,
+ADD COLUMN     "rating" DOUBLE PRECISION;

--- a/prisma/migrations/20250309003230_modify_job_log_table_and_add_job_table/migration.sql
+++ b/prisma/migrations/20250309003230_modify_job_log_table_and_add_job_table/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `jobName` on the `JobLog` table. All the data in the column will be lost.
+  - You are about to drop the column `runAt` on the `JobLog` table. All the data in the column will be lost.
+  - Added the required column `jobId` to the `JobLog` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "JobLog" DROP COLUMN "jobName",
+DROP COLUMN "runAt",
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "jobId" INTEGER NOT NULL;
+
+-- CreateTable
+CREATE TABLE "Job" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+
+    CONSTRAINT "Job_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "JobLog" ADD CONSTRAINT "JobLog_jobId_fkey" FOREIGN KEY ("jobId") REFERENCES "Job"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,11 +7,39 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model Job {
+  id          Int      @id @default(autoincrement())
+  name        String
+  description String
+  jobLogs     JobLog[] // Relation to JobLog table
+}
+
+model JobLog {
+  id        Int      @id @default(autoincrement())
+  message   String
+  createdAt DateTime @default(now()) // Automatically sets the current timestamp
+  jobId     Int      // Foreign key to Job table
+  job       Job      @relation(fields: [jobId], references: [id]) // Link to Job table
+}
+
 model User {
   id       Int     @id @default(autoincrement())
   username String  @unique              // Unique username
   email    String  @unique              // Unique email
   name     String
   createdAt DateTime @default(now())    // Timestamp
+}
+
+model Location {
+  id                 Int     @id @default(autoincrement())
+  name               String
+  latitude           Float
+  longitude          Float
+  category           String
+  address            String
+  googlePlaceId      String  @unique
+  profilePicture     String?
+  rating             Float?
+  googleRatingsTotal Int?
 }
 

--- a/scripts/fetchPlaces.ts
+++ b/scripts/fetchPlaces.ts
@@ -1,0 +1,120 @@
+import { PrismaClient } from '@prisma/client';
+import axios from 'axios';
+
+const prisma = new PrismaClient();
+const GOOGLE_API_KEY = process.env.GOOGLE_PLACES_API_KEY!;
+const CITY = process.env.CITY || "Toronto";
+const PLACE_TYPES = ["library", "cafe", "coworking_space"];
+const MAX_PLACES = 20;
+
+const JOB_ID = 1;  // Static Job ID
+
+// Define type for Place API response (simplified version)
+interface GooglePlace {
+  name: string;
+  formatted_address: string;
+  place_id: string;
+  geometry: {
+    location: {
+      lat: number;
+      lng: number;
+    };
+  };
+  photos?: {
+    photo_reference: string;
+  }[];
+  rating?: number;
+  user_ratings_total?: number;
+}
+
+// Function to insert job log with foreign key to Job table
+async function logMessage(message: string): Promise<void> {
+  await prisma.jobLog.create({
+    data: {
+      message,
+      createdAt: new Date(), // Insert the current time as createdAt
+      jobId: JOB_ID, // Use static jobId = 1 for this job
+    },
+  });
+}
+
+// Check if the script has run too many times today (already ran twice)
+async function hasRunTooManyTimes(): Promise<boolean> {
+  const startOfDay = new Date();
+  startOfDay.setHours(0, 0, 0, 0);
+
+  const count = await prisma.jobLog.count({
+    where: { jobId: JOB_ID, createdAt: { gte: startOfDay } },
+  });
+
+  return count >= 2;
+}
+
+// Main function to fetch places from Google API and insert into DB
+async function fetchPlaces(): Promise<void> {
+  // We are assuming jobId = 1 is already created manually, so no need to check for job creation
+  if (await hasRunTooManyTimes()) {
+    await logMessage("Script already ran twice today. Exiting.");
+    return;
+  }
+
+  await logMessage("Script started. Fetching study spots.");
+
+  let totalInserted = 0;
+
+  for (const type of PLACE_TYPES) {
+    if (totalInserted >= MAX_PLACES) break;
+
+    const url = `https://maps.googleapis.com/maps/api/place/textsearch/json?query=${type}+in+${CITY}&key=${GOOGLE_API_KEY}`;
+
+    try {
+      const response = await axios.get(url);
+      const places: GooglePlace[] = response.data.results;
+
+      for (const place of places) {
+        if (totalInserted >= MAX_PLACES) break;
+
+        const exists = await prisma.location.findUnique({
+          where: { googlePlaceId: place.place_id },
+        });
+
+        if (!exists) {
+          await prisma.location.create({
+            data: {
+              name: place.name,
+              latitude: place.geometry.location.lat,
+              longitude: place.geometry.location.lng,
+              category: type,
+              address: place.formatted_address,
+              googlePlaceId: place.place_id,
+              profilePicture: place.photos?.[0]
+                ? `https://maps.googleapis.com/maps/api/place/photo?maxwidth=400&photoreference=${place.photos[0].photo_reference}&key=${GOOGLE_API_KEY}`
+                : null,
+              rating: place.rating || null, // Store rating (if available)
+              googleRatingsTotal: place.user_ratings_total || null, // Store total ratings (if available)
+            },
+          });
+
+          await logMessage(
+            `Inserted: ${place.name} (Rating: ${place.rating || "N/A"}, Reviews: ${place.user_ratings_total || 0})`
+          );
+          totalInserted++;
+        } else {
+          await logMessage(`Already exists: ${place.name}`);
+        }
+      }
+    } catch (error) {
+      if(error instanceof Error){
+        await logMessage(`Error fetching places for type ${type}: ${error.message}`);
+      }
+      else {
+        await logMessage(`Unkown error occured when fetching new places`);
+      }
+    }
+  }
+
+  await logMessage(`Finished fetching. Inserted ${totalInserted} new places.`);
+  await prisma.$disconnect();
+}
+
+fetchPlaces();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This PR fixes #5

Adding job, job log and location tables, script that fetches study spots from Google Places API, job logging functionality.

Job table contains metadata of a job that runs. Added Fetch Places job (Job ID 1) to fetch 20 (for now) places from Google Places API and store them into our database if they don't already exist. Job Log table stores any logs emitted from a job script and is linked to the Job table using the Job Id foreign key. 